### PR TITLE
Implement functions to check for KVM version and extensions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,10 +35,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "vmd"
 version = "0.1.0"
 dependencies = [
  "kvm-ioctls",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Ville Ilvonen <ville.ilvonen@unikie.com>", ]
 
 [dependencies]
 kvm-ioctls = { version = "0.12.0" }
+thiserror = "1.0.38"

--- a/src/kvm_util.rs
+++ b/src/kvm_util.rs
@@ -1,29 +1,88 @@
-use kvm_ioctls::Kvm;
+#![allow(unused)]
+use kvm_ioctls::{
+    Kvm, Cap
+};
+use thiserror::Error;
 
-/// ```
-/// use kvm_util::get_kvm_api_version;
-/// //"Applications should refuse to run if KVM_GET_API_VERSION
-/// // returns a value other than 12."
-/// // https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt
-/// let api_version = get_kvm_api_version();
-/// assert_eq!(api_version, 12);
-/// ```
-pub fn get_kvm_api_version() -> i32 {
-    let kvm = Kvm::new().unwrap(); //TODO
-    let kvm_api_version: i32 = kvm.get_api_version();
-    assert_eq!(kvm_api_version, 12); // clients must check to continue
-    kvm_api_version
+#[derive(Debug, Error)]
+pub enum VdmError {
+    #[error("Requires KVM version {REQUIRED_KVM_API_VERSION} or higher")]
+    IncorrectKvmApiVersion(i32),
+    #[error("Missing the following KVM extensions {0:?}")]
+    MissingExtensions(Vec<Cap>),
 }
 
+pub const REQUIRED_KVM_API_VERSION: i32 = 12;
 
-/*fn main() {
+pub const REQUIRED_KVM_EXTENSIONS: [Cap; 1] = [
+    Cap::UserMemory,
+];
 
+/// Checks if the KVM API version is high enough. Required version
+/// is defined by `REQUIRED_KVM_API_VERSION`.
+///
+/// https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt
+///
+/// # Example
+///
+/// ```
+/// match check_kvm_api_version() {
+///     Ok(version) => println!("KVM API version: {}", version),
+///     Err(e) => eprintln!("Error: {:?}", e),
+/// }
+/// ```
+pub fn check_kvm_api_version() -> Result<i32, VdmError> {
+    let kvm = Kvm::new().unwrap();
+    let api_version = kvm.get_api_version();
+    if api_version < REQUIRED_KVM_API_VERSION {
+        return Err(VdmError::IncorrectKvmApiVersion(api_version));
+    }
+    Ok(api_version)
+}
 
-    println!("Recommended number of VCPUs per VM:         {}", kvm.get_nr_vcpus());
-    println!("Recommended maximum number of VCPUs per VM: {}", kvm.get_max_vcpus());
-    println!("Maximum allowed memory slots per VM:        {}", kvm.get_nr_memslots());
-    println!("KVM capabilities available:");
-    println!("  IOMMU {}", kvm.check_extension(Cap::Iommu));
-    println!("  UserMemory {}", kvm.check_extension(Cap::UserMemory));
+/// Check if device has the required KVM extensions. In case of
+/// missing extensions, returns a list of missing extensions wrapped
+/// in a `VdmError::MissingExtensions(Vec<Cap>)` error.
+///
+/// # Example
+///
+/// ```
+/// match check_kvm_extensions() {
+///    Ok(_) => println!("Has all required KVM extensions"),
+///    Err(e) => eprintln!("Error: {:?}", e),
+/// }
+/// ```
+pub fn check_kvm_extensions() -> Result<(), VdmError> {
+    let kvm = Kvm::new().unwrap();
+    let mut missing_extensions = Vec::new();
+    for extension in &REQUIRED_KVM_EXTENSIONS {
+        if !kvm.check_extension(*extension) {
+            missing_extensions.push(*extension);
+        }
+    }
+    if !missing_extensions.is_empty() {
+        return Err(VdmError::MissingExtensions(missing_extensions));
+    }
+    Ok(())
+}
 
-}*/
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_kvm_api_version() {
+        match check_kvm_api_version() {
+            Ok(version) => println!("KVM API version: {}", version),
+            Err(e) => eprintln!("Error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_check_kvm_extensions() {
+        match check_kvm_extensions() {
+            Ok(()) => println!("KVM extensions OK"),
+            Err(e) => eprintln!("Error: {:?}", e),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 mod kvm_util;
 
-use crate::kvm_util::get_kvm_api_version;
-
 fn main() {
-    let api_version: i32 =  get_kvm_api_version();
-    println!("hello kvm_api {}", api_version)
+    match kvm_util::check_kvm_api_version() {
+        Ok(version) => println!("KVM API version: {}", version),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+    match kvm_util::check_kvm_extensions() {
+        Ok(()) => println!("KVM extensions OK"),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
 }


### PR DESCRIPTION
We want to query the kernel virtual machine KVM for API version and required extensions.

- [x] Implement error handling
- [x] Implement function check_kvm_api_version
- [x] Implement function check_kvm_extensions
- [ ] Define required extensions

KVM API documentation https://www.kernel.org/doc/Documentation/virtual/kvm/api.txt

Things to note:

- KVM API docs say that all basic capabilities are guaranteed to be present on a system that implements KVM api version 12 or more.

```
Capability: which KVM extension provides this ioctl.  Can be 'basic',
      which means that is will be provided by any kernel that supports
      API version 12 (see section 4.1)
```
- Required extensions can be added by mainpulating the global array REQUIRED_KVM_EXTENSIONS
- Minimum required version is defined by REQUIRED_KVM_API_VERSION