### PR TITLE
Initial nixosModules for vmd-client and vmd-server

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,5 +30,11 @@
 
         formatter = nixpkgs.legacyPackages.${system}.alejandra;
       }
-    );
+    )
+    // {
+      nixosModules = {
+        vmd-client = import ./nixos-modules/vmd-client.nix;
+        vmd-server = import ./nixos-modules/vmd-server.nix;
+      };
+    };
 }

--- a/nixos-modules/vmd-client.nix
+++ b/nixos-modules/vmd-client.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.vmd-client;
+  cfgS = config.services.vmd-server;
+in {
+  options.programs.vmd-client = {
+    enable = mkEnableOption "vmd-client";
+
+    package = mkOption {
+      type = types.package;
+      default =
+        (pkgs.callPackage ../vmd-client {
+          vmd-rust-client-api = pkgs.callPackage ../vmd-api/rust-client.nix {};
+        })
+        # TODO: Default config file path for vmd-client would be nicer than
+        #       this hackery
+        .overrideAttrs (prevAttrs: let
+          vmdClientArgs = lib.concatStringsSep " " ([
+              "--add-flags"
+              "--hostname"
+              "--add-flags"
+              cfgS.bindAddress
+              "--add-flags"
+              "--port"
+              "--add-flags"
+              (builtins.toString cfgS.port)
+              "--add-flags"
+              "--cacert"
+              "--add-flags"
+              cfgS.caCertPath
+            ]
+            ++ lib.optionals cfgS.generateKeys
+            [
+              "--add-flags"
+              "--cert"
+              "--add-flags"
+              "/run/vmd/sample-vmd-client-chain.pem"
+              "--add-flags"
+              "--key"
+              "--add-flags"
+              "/run/vmd/sample-vmd-client-key.pem"
+            ]);
+        in
+          lib.optionalAttrs cfgS.enable {
+            nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [pkgs.makeWrapper];
+            postFixup = ''
+              wrapProgram $out/bin/vmd-client ${vmdClientArgs}
+            '';
+          });
+      description = mdDoc "The package to use for the vmd-client binary.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+  };
+}

--- a/nixos-modules/vmd-keygen.nix
+++ b/nixos-modules/vmd-keygen.nix
@@ -1,0 +1,103 @@
+{
+  bash,
+  openssl,
+  writeShellScriptBin,
+  vmd-user,
+  vmd-group,
+  caCertPath,
+  tlsCertPath,
+  tlsKeyPath,
+}: let
+  dir = "/run/vmd";
+  protocol = "x509";
+  cipherSuite = "TLS_AES_256_GCM_SHA384";
+  keySize = 4096;
+  validityDays = 9999;
+
+  caKey = "${dir}/sample-ca-key.pem";
+  caCrt = "${caCertPath}";
+
+  vmdServerKey = "${tlsKeyPath}";
+  vmdServerCsr = "${dir}/sample-vmd-server-csr.pem";
+  vmdServerCrt = "${tlsCertPath}";
+  vmdServerChain = "${dir}/sample-vmd-server-chain.pem";
+
+  vmdClientKey = "${dir}/sample-vmd-client-key.pem";
+  vmdClientCsr = "${dir}/sample-vmd-client-csr.pem";
+  vmdClientCrt = "${dir}/sample-vmd-client-crt.pem";
+  vmdClientChain = "${dir}/sample-vmd-client-chain.pem";
+
+  country = "FI";
+  state = "Uusimaa";
+  locality = "Helsinki";
+  organization = "VMD";
+  organizationUnit = "VMD";
+
+  caCommonName = "vmd-ca";
+  # TLS requires URL's to match so we use localhost
+  vmdServerCommonName = "localhost";
+  vmdClientCommonName = "vmd-client";
+
+  alt = "DNS:localhost";
+
+  password = "1234";
+  caSubject = "/C=${country}/ST=${state}/L=${locality}/O=${organization}/OU=${organizationUnit}/CN=${caCommonName}";
+  serverSubject = "/C=${country}/ST=${state}/L=${locality}/O=${organization}/OU=${organizationUnit}/CN=${vmdServerCommonName}";
+  clientSubject = "/C=${country}/ST=${state}/L=${locality}/O=${organization}/OU=${organizationUnit}/CN=${vmdClientCommonName}";
+
+  ossl = "${openssl}/bin/openssl";
+in
+  writeShellScriptBin "vmd-keygen" ''
+    set -euo pipefail
+
+    mkdir -p ${dir}
+    chmod 550 ${dir}
+    umask 007
+
+    echo "Generating CA key and certificate"
+    ${ossl} req -new -${protocol} \
+      -days ${builtins.toString validityDays} \
+      -keyout ${caKey} \
+      -out ${caCrt} \
+      -passout pass:${password} \
+      -subj "${caSubject}"
+
+    echo "Generating vmd-server key and certificate signing request"
+    ${ossl} genrsa -out ${vmdServerKey} ${builtins.toString keySize}
+    ${ossl} req -new \
+        -key ${vmdServerKey} \
+        -out ${vmdServerCsr} \
+        -passin pass:${password} \
+        -subj "${serverSubject}"
+    ${bash}/bin/bash -c '${ossl} ${protocol} -req \
+        -days ${builtins.toString validityDays} \
+        -in ${vmdServerCsr} \
+        -CA ${caCrt} \
+        -CAkey ${caKey} -CAcreateserial \
+        -passin pass:${password} \
+        -out ${vmdServerCrt} \
+        -extfile <(printf "subjectAltName=${alt}")'
+    ${ossl} verify -CAfile ${caCrt} ${vmdServerCrt}
+    cat ${vmdServerCrt} ${vmdServerKey} > ${vmdServerChain}
+
+    echo "Generating client key and certificate signing request"
+    ${ossl} genrsa -out ${vmdClientKey} ${builtins.toString keySize}
+    ${ossl} req -new \
+        -key ${vmdClientKey} \
+        -out ${vmdClientCsr} \
+        -passin pass:${password} \
+        -subj "${clientSubject}"
+    ${bash}/bin/bash -c '${ossl} ${protocol} -req \
+        -days ${builtins.toString validityDays} \
+        -in ${vmdClientCsr} \
+        -CA ${caCrt} \
+        -CAkey ${caKey} -CAcreateserial \
+        -passin pass:${password} \
+        -out ${vmdClientCrt} \
+        -extfile <(printf "subjectAltName=${alt}")'
+    ${ossl} verify -CAfile ${caCrt} ${vmdClientCrt}
+    cat ${vmdClientCrt} ${vmdClientKey} > ${vmdClientChain}
+
+    # TODO: File permissions need additional tweaking for security
+    chown -R ${vmd-user}:${vmd-group} ${dir} ${caCertPath} ${tlsCertPath} ${tlsKeyPath}
+  ''

--- a/nixos-modules/vmd-server.nix
+++ b/nixos-modules/vmd-server.nix
@@ -1,0 +1,139 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.vmd-server;
+  defaultUser = "vmd-server";
+  defaultGroup = "vmd";
+in {
+  options.services.vmd-server = {
+    enable = mkEnableOption "vmd-server";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.callPackage ../vmd-server {
+        vmd-rust-server-api = pkgs.callPackage ../vmd-api/rust-server.nix {};
+      };
+      description = mdDoc "The package to use for the vmd-server binary.";
+    };
+
+    generateKeys = mkEnableOption "generate keys during the boot";
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      example = "vmd-server";
+      description = mdDoc ''
+        The user for the service. If left as the default value this user will
+        automatically be created.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = defaultGroup;
+      example = "vmd";
+      description = mdDoc ''
+        The group for the service. If left as the default value this group will
+        automatically be created.
+      '';
+    };
+
+    bindAddress = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = mdDoc "vmd-server listening address.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 9876;
+      description = mdDoc "vmd-server listening port.";
+    };
+
+    caCertPath = mkOption {
+      type = types.path;
+      default = "/run/vmd/sample-ca-cert.pem";
+      description = mdDoc "vmd-server certificate authority file.";
+    };
+
+    tlsCertPath = mkOption {
+      type = types.path;
+      default = "/run/vmd/sample-vmd-server-crt.pem";
+      description = mdDoc "vmd-server certificate file.";
+    };
+
+    tlsKeyPath = mkOption {
+      type = types.path;
+      default = "/run/vmd/sample-vmd-server-key.pem";
+      description = mdDoc "vmd-server private key file.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users = mkIf (cfg.user == defaultUser) {
+        vmd-server = {
+          group = cfg.group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == defaultGroup) {
+        vmd = {};
+      };
+    };
+    systemd.services."vmd-keygen" = let
+      keygenScript = pkgs.callPackage ./vmd-keygen.nix {
+        vmd-user = cfg.user;
+        vmd-group = cfg.group;
+        inherit (cfg) caCertPath tlsCertPath tlsKeyPath;
+      };
+    in
+      mkIf cfg.generateKeys {
+        enable = true;
+        description = "Generate keys for Virtual Machine Daemon";
+        documentation = ["https://github.com/tiiuae/vmd"];
+        path = [keygenScript];
+        before = ["vmd-server.service"];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          StandardOutput = "journal";
+          StandardError = "journal";
+          ExecStart = "${keygenScript}/bin/vmd-keygen";
+        };
+      };
+    systemd.services."vmd-server" = {
+      enable = true;
+      wants = mkIf cfg.generateKeys ["vmd-keygen.service"];
+      wantedBy = ["multi-user.target"];
+      description = "Virtual Machine Daemon";
+      documentation = ["https://github.com/tiiuae/vmd"];
+      path = [cfg.package];
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "simple";
+        StandardOutput = "journal";
+        StandardError = "journal";
+        Environment = "RUST_LOG=trace";
+        ExecStart = lib.concatStringsSep " " [
+          "${cfg.package}/bin/vmd-server"
+          "--hostname"
+          cfg.bindAddress
+          "--port"
+          (builtins.toString cfg.port)
+          "--cacert"
+          cfg.caCertPath
+          "--cert"
+          cfg.tlsCertPath
+          "--key"
+          cfg.tlsKeyPath
+        ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
* Adapt the sample key generation from Makefile to shell script in vmd-keygen.nix, which could be then run as systemd service to generate necessary keys.
* Options module and systemd service for vmd-server. Support for configuring all the various options via options module.
* Options module for vmd-client, which is also wrapped with wrapProgram to provide the default hostname, port, cacert, cert and key arguments.