### PR TITLE
flake: limit systems to x86_64|aarch64 on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,13 @@
     nixpkgs,
     flake-utils,
     ...
-  }:
-    flake-utils.lib.eachDefaultSystem (
+  }: let
+    systems = with flake-utils.lib.system; [
+      x86_64-linux
+      aarch64-linux
+    ];
+  in
+    flake-utils.lib.eachSystem systems (
       system: let
         pkgs = import nixpkgs {
           inherit system;


### PR DESCRIPTION
* drop darwin (MacOS) targets from flake-utils defaultSystems. MacOS is not supported.
* cleans nix flake show targets by removing the unsupported target systems from the output.